### PR TITLE
Support Path-like objects

### DIFF
--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -18,8 +18,11 @@ from typing import (
     Mapping,
     NamedTuple,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
+    Union,
+    runtime_checkable
 )
 
 import filelock
@@ -1083,3 +1086,22 @@ def get_log_threshold_for_error(conf: Config, err: str) -> int:
         return conf.retry_common_log_threshold
     else:
         return conf.retry_log_threshold
+
+
+@runtime_checkable
+class BlobPathLike(Protocol):
+    """Similar to the __fspath__ protocol, but for remote blob paths."""
+    def __blobpath__(self) -> str:
+        ...
+
+
+RemoteOrLocalPath = Union[str, BlobPathLike, os.PathLike[str]]
+
+
+def path_to_str(path: RemoteOrLocalPath) -> str:
+    if isinstance(path, BlobPathLike):
+        return path.__blobpath__()
+    elif isinstance(path, os.PathLike):
+        return path.__fspath__()
+    else:
+        return path

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -61,7 +61,9 @@ from blobfile._common import (
     Request,
     RestartableStreamingWriteFailure,
     Stat,
+    RemoteOrLocalPath,
     get_log_threshold_for_error,
+    path_to_str,
 )
 
 # https://cloud.google.com/storage/docs/naming
@@ -89,14 +91,16 @@ class Context:
 
     def copy(
         self,
-        src: str,
-        dst: str,
+        src: RemoteOrLocalPath,
+        dst: RemoteOrLocalPath,
         overwrite: bool = False,
         parallel: bool = False,
         parallel_executor: Optional[concurrent.futures.Executor] = None,
         return_md5: bool = False,
         dst_version: Optional[str] = None,
     ) -> Optional[str]:
+        src = path_to_str(src)
+        dst = path_to_str(dst)
         # it would be best to check isdir() for remote paths, but that would
         # involve 2 extra network requests, so just do this test instead
         if _guess_isdir(src):
@@ -199,7 +203,8 @@ class Context:
                     )
                 time.sleep(backoff)
 
-    def exists(self, path: str) -> bool:
+    def exists(self, path: RemoteOrLocalPath) -> bool:
+        path = path_to_str(path)
         if _is_local_path(path):
             return os.path.exists(path)
         elif _is_gcp_path(path):
@@ -215,7 +220,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
-    def basename(self, path: str) -> str:
+    def basename(self, path: RemoteOrLocalPath) -> str:
+        path = path_to_str(path)
         if _is_gcp_path(path):
             _, obj = gcp.split_path(path)
             return obj.split("/")[-1]
@@ -353,7 +359,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path '{pattern}'")
 
-    def isdir(self, path: str) -> bool:
+    def isdir(self, path: RemoteOrLocalPath) -> bool:
+        path = path_to_str(path)
         if _is_local_path(path):
             return os.path.isdir(path)
         elif _is_gcp_path(path):
@@ -363,11 +370,13 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
-    def listdir(self, path: str, shard_prefix_length: int = 0) -> Iterator[str]:
+    def listdir(self, path: RemoteOrLocalPath, shard_prefix_length: int = 0) -> Iterator[str]:
+        path = path_to_str(path)
         for entry in self.scandir(path, shard_prefix_length=shard_prefix_length):
             yield entry.name
 
-    def scandir(self, path: str, shard_prefix_length: int = 0) -> Iterator[DirEntry]:
+    def scandir(self, path: RemoteOrLocalPath, shard_prefix_length: int = 0) -> Iterator[DirEntry]:
+        path = path_to_str(path)
         if (_is_gcp_path(path) or _is_azure_path(path)) and not path.endswith("/"):
             path += "/"
         if not self.exists(path):
@@ -444,7 +453,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
-    def makedirs(self, path: str) -> None:
+    def makedirs(self, path: RemoteOrLocalPath) -> None:
+        path = path_to_str(path)
         if _is_local_path(path):
             os.makedirs(path, exist_ok=True)
         elif _is_gcp_path(path):
@@ -454,7 +464,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
-    def remove(self, path: str) -> None:
+    def remove(self, path: RemoteOrLocalPath) -> None:
+        path = path_to_str(path)
         if _is_local_path(path):
             os.remove(path)
         elif _is_gcp_path(path):
@@ -476,7 +487,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
-    def rmdir(self, path: str) -> None:
+    def rmdir(self, path: RemoteOrLocalPath) -> None:
+        path = path_to_str(path)
         if _is_local_path(path):
             os.rmdir(path)
             return
@@ -537,7 +549,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
-    def stat(self, path: str) -> Stat:
+    def stat(self, path: RemoteOrLocalPath) -> Stat:
+        path = path_to_str(path)
         if _is_local_path(path):
             s = os.stat(path)
             return Stat(
@@ -560,7 +573,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
-    def set_mtime(self, path: str, mtime: float, version: Optional[str] = None) -> bool:
+    def set_mtime(self, path: RemoteOrLocalPath, mtime: float, version: Optional[str] = None) -> bool:
+        path = path_to_str(path)
         if _is_local_path(path):
             assert version is None
             os.utime(path, times=(mtime, mtime))
@@ -574,10 +588,11 @@ class Context:
 
     def rmtree(
         self,
-        path: str,
+        path: RemoteOrLocalPath,
         parallel: bool = False,
         parallel_executor: Optional[concurrent.futures.Executor] = None,
     ) -> None:
+        path = path_to_str(path)
         if not self.isdir(path):
             raise NotADirectoryError(f"The directory name is invalid: '{path}'")
 
@@ -671,10 +686,11 @@ class Context:
 
     def walk(
         self,
-        top: str,
+        top: RemoteOrLocalPath,
         topdown: bool = True,
         onerror: Optional[Callable[[OSError], None]] = None,
     ) -> Iterator[Tuple[str, Sequence[str], Sequence[str]]]:
+        top = path_to_str(top)
         if not self.isdir(top):
             return
 
@@ -764,7 +780,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{top}'")
 
-    def dirname(self, path: str) -> str:
+    def dirname(self, path: RemoteOrLocalPath) -> str:
+        path = path_to_str(path)
         if _is_gcp_path(path):
             return gcp.dirname(self._conf, path)
         elif _is_azure_path(path):
@@ -772,13 +789,15 @@ class Context:
         else:
             return os.path.dirname(path)
 
-    def join(self, a: str, *args: str) -> str:
+    def join(self, a: RemoteOrLocalPath, *args: str) -> str:
+        a = path_to_str(a)
         out = a
         for b in args:
             out = _join2(self._conf, out, b)
         return out
 
-    def get_url(self, path: str) -> Tuple[str, Optional[float]]:
+    def get_url(self, path: RemoteOrLocalPath) -> Tuple[str, Optional[float]]:
+        path = path_to_str(path)
         if _is_gcp_path(path):
             return gcp.get_url(self._conf, path)
         elif _is_azure_path(path):
@@ -788,7 +807,8 @@ class Context:
         else:
             raise Error(f"Unrecognized path: '{path}'")
 
-    def md5(self, path: str) -> str:
+    def md5(self, path: RemoteOrLocalPath) -> str:
+        path = path_to_str(path)
         if _is_gcp_path(path):
             st = gcp.maybe_stat(self._conf, path)
             if st is None:
@@ -825,7 +845,7 @@ class Context:
     @overload
     def BlobFile(
         self,
-        path: str,
+        path: RemoteOrLocalPath,
         mode: Literal["rb", "wb", "ab"],
         streaming: Optional[bool] = ...,
         buffer_size: int = ...,
@@ -838,7 +858,7 @@ class Context:
     @overload
     def BlobFile(
         self,
-        path: str,
+        path: RemoteOrLocalPath,
         mode: Literal["r", "w", "a"] = ...,
         streaming: Optional[bool] = ...,
         buffer_size: int = ...,
@@ -850,7 +870,7 @@ class Context:
 
     def BlobFile(
         self,
-        path: str,
+        path: RemoteOrLocalPath,
         mode: Literal["r", "rb", "w", "wb", "a", "ab"] = "r",
         streaming: Optional[bool] = None,
         buffer_size: Optional[int] = None,
@@ -881,6 +901,7 @@ class Context:
         Returns:
             A file-like object
         """
+        path = path_to_str(path)
         if _guess_isdir(path):
             raise IsADirectoryError(f"Is a directory: '{path}'")
 

--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     # c) type checkers always know what typing_extensions is
     from typing_extensions import Literal
 
-from blobfile._common import DirEntry, Stat
+from blobfile._common import DirEntry, Stat, RemoteOrLocalPath
 from blobfile._context import (
     DEFAULT_AZURE_WRITE_CHUNK_SIZE,
     DEFAULT_BUFFER_SIZE,
@@ -104,8 +104,8 @@ def configure(
 
 
 def copy(
-    src: str,
-    dst: str,
+    src: RemoteOrLocalPath,
+    dst: RemoteOrLocalPath,
     overwrite: bool = False,
     parallel: bool = False,
     parallel_executor: Optional[concurrent.futures.Executor] = None,
@@ -141,14 +141,14 @@ def copy(
     )
 
 
-def exists(path: str) -> bool:
+def exists(path: RemoteOrLocalPath) -> bool:
     """
     Return true if that path exists (either as a file or a directory)
     """
     return default_context.exists(path=path)
 
 
-def basename(path: str) -> str:
+def basename(path: RemoteOrLocalPath) -> str:
     """
     Get the filename component of the path
 
@@ -183,14 +183,14 @@ def scanglob(
     )
 
 
-def isdir(path: str) -> bool:
+def isdir(path: RemoteOrLocalPath) -> bool:
     """
     Return true if a path is an existing directory
     """
     return default_context.isdir(path=path)
 
 
-def listdir(path: str, shard_prefix_length: int = 0) -> Iterator[str]:
+def listdir(path: RemoteOrLocalPath, shard_prefix_length: int = 0) -> Iterator[str]:
     """
     Returns an iterator of the contents of the directory at `path`
 
@@ -204,42 +204,42 @@ def listdir(path: str, shard_prefix_length: int = 0) -> Iterator[str]:
     return default_context.listdir(path=path, shard_prefix_length=shard_prefix_length)
 
 
-def scandir(path: str, shard_prefix_length: int = 0) -> Iterator[DirEntry]:
+def scandir(path: RemoteOrLocalPath, shard_prefix_length: int = 0) -> Iterator[DirEntry]:
     """
     Same as `listdir`, but returns `DirEntry` objects instead of strings
     """
     return default_context.scandir(path=path, shard_prefix_length=shard_prefix_length)
 
 
-def makedirs(path: str) -> None:
+def makedirs(path: RemoteOrLocalPath) -> None:
     """
     Make any directories necessary to ensure that path is a directory
     """
     return default_context.makedirs(path=path)
 
 
-def remove(path: str) -> None:
+def remove(path: RemoteOrLocalPath) -> None:
     """
     Remove a file at the given path
     """
     return default_context.remove(path=path)
 
 
-def rmdir(path: str) -> None:
+def rmdir(path: RemoteOrLocalPath) -> None:
     """
     Remove an empty directory at the given path
     """
     return default_context.rmdir(path=path)
 
 
-def stat(path: str) -> Stat:
+def stat(path: RemoteOrLocalPath) -> Stat:
     """
     Stat a file or object representing a directory, returns a Stat object
     """
     return default_context.stat(path=path)
 
 
-def set_mtime(path: str, mtime: float, version: Optional[str] = None) -> bool:
+def set_mtime(path: RemoteOrLocalPath, mtime: float, version: Optional[str] = None) -> bool:
     """
     Set the mtime for a path, returns True on success
 
@@ -250,7 +250,7 @@ def set_mtime(path: str, mtime: float, version: Optional[str] = None) -> bool:
 
 
 def rmtree(
-    path: str,
+    path: RemoteOrLocalPath,
     parallel: bool = False,
     parallel_executor: Optional[concurrent.futures.Executor] = None,
 ) -> None:
@@ -263,7 +263,7 @@ def rmtree(
 
 
 def walk(
-    top: str, topdown: bool = True, onerror: Optional[Callable[[OSError], None]] = None
+    top: RemoteOrLocalPath, topdown: bool = True, onerror: Optional[Callable[[OSError], None]] = None
 ) -> Iterator[Tuple[str, Sequence[str], Sequence[str]]]:
     """
     Walk a directory tree in a similar manner to os.walk
@@ -271,7 +271,7 @@ def walk(
     return default_context.walk(top=top, topdown=topdown, onerror=onerror)
 
 
-def dirname(path: str) -> str:
+def dirname(path: RemoteOrLocalPath) -> str:
     """
     Get the directory name of the path
 
@@ -281,21 +281,21 @@ def dirname(path: str) -> str:
     return default_context.dirname(path=path)
 
 
-def join(a: str, *args: str) -> str:
+def join(a: RemoteOrLocalPath, *args: str) -> str:
     """
     Join file paths, if a path is an absolute path, it will replace the entire path component of previous paths
     """
     return default_context.join(a, *args)
 
 
-def get_url(path: str) -> Tuple[str, Optional[float]]:
+def get_url(path: RemoteOrLocalPath) -> Tuple[str, Optional[float]]:
     """
     Get a URL for the given path that a browser could open
     """
     return default_context.get_url(path=path)
 
 
-def md5(path: str) -> str:
+def md5(path: RemoteOrLocalPath) -> str:
     """
     Get the MD5 hash for a file in hexdigest format.
 
@@ -309,7 +309,7 @@ def md5(path: str) -> str:
 
 @overload
 def BlobFile(
-    path: str,
+    path: RemoteOrLocalPath,
     mode: Literal["rb", "wb", "ab"],
     streaming: Optional[bool] = ...,
     buffer_size: int = ...,
@@ -322,7 +322,7 @@ def BlobFile(
 
 @overload
 def BlobFile(
-    path: str,
+    path: RemoteOrLocalPath,
     mode: Literal["r", "w", "a"] = ...,
     streaming: Optional[bool] = ...,
     buffer_size: int = ...,
@@ -334,7 +334,7 @@ def BlobFile(
 
 
 def BlobFile(
-    path: str,
+    path: RemoteOrLocalPath,
     mode: Literal["r", "rb", "w", "wb", "a", "ab"] = "r",
     streaming: Optional[bool] = None,
     buffer_size: Optional[int] = None,


### PR DESCRIPTION
This change allows passing Path-like objects to most functions in blobfile.
- Local path-like objects are supported using the `__fspath__` protocol from PEP 519.
  - This adds support for `pathlib.Path`.
- Remote path-like objects are supported using the `__blobpath__` protocol proposed by @hauntsaninja.
  - Using a separate protocol for these means that a RemotePath class can define it and be passed to blobfile without type checkers thinking that it can also be passed to os.path.exists etc., as would be the case if it implemented `__fspath__`.

Objects implementing these protocols are immediately converted to strings by invoking the appropriate method as soon as they are passed to blobfile. Strings are passed through unchanged.

We use Protocol to define the typing and identify objects supporting `__blobpath__`; this requires Python 3.8. The implementation can be changed to support older versions of Python if desired.