### PR TITLE
Improve exception handling

### DIFF
--- a/blobfile/_azure.py
+++ b/blobfile/_azure.py
@@ -1193,7 +1193,12 @@ class StreamingWriteFile(BaseStreamingWriteFile):
                 # from the 400 status code)
                 retry_codes=(400,) + DEFAULT_RETRY_CODES,
             )
-            execute_api_request(self._conf, req)
+            try:
+                execute_api_request(self._conf, req)
+            except Exception:
+                del chunk, data, req.data, req
+                raise
+
             self._block_index += 1
             if self._block_index >= BLOCK_COUNT_LIMIT:
                 raise Error(

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -599,7 +599,7 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
                     else:
                         raise RequestFailure.create_from_request_response(
                             "host does not exist", request=req, response=fake_resp
-                        )
+                        ) from e
 
             err = RequestFailure.create_from_request_response(
                 message=f"request failed with exception {e}",
@@ -730,9 +730,12 @@ class BaseStreamingWriteFile(io.BufferedIOBase):
             size = (len(buf) // self._chunk_size) * self._chunk_size
             assert size > 0
 
-        chunk = buf[:size]
-        self._upload_chunk(chunk, finalize)
-        self._offset += len(chunk)
+        try:
+            chunk = buf[:size]
+            self._upload_chunk(chunk, finalize)
+            self._offset += len(chunk)
+        finally:
+            del chunk, buf
         return size
 
     def close(self) -> None:
@@ -761,9 +764,12 @@ class BaseStreamingWriteFile(io.BufferedIOBase):
         else:
             self._buf += b
             if len(self._buf) >= self._chunk_size:
-                mv = memoryview(self._buf)
-                size = self._upload_buf(mv)
-                self._buf = bytearray(mv[size:])
+                try:
+                    mv = memoryview(self._buf)
+                    size = self._upload_buf(mv)
+                    self._buf = bytearray(mv[size:])
+                finally:
+                    del mv
         assert len(self._buf) < self._chunk_size
         return len(b)
 

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -735,7 +735,7 @@ class BaseStreamingWriteFile(io.BufferedIOBase):
             self._upload_chunk(chunk, finalize)
             self._offset += len(chunk)
         finally:
-            del chunk, buf
+            del chunk, buf  # pyright: ignore[reportUnboundVariable]
         return size
 
     def close(self) -> None:
@@ -769,7 +769,7 @@ class BaseStreamingWriteFile(io.BufferedIOBase):
                     size = self._upload_buf(mv)
                     self._buf = bytearray(mv[size:])
                 finally:
-                    del mv
+                    del mv  # pyright: ignore[reportUnboundVariable]
         assert len(self._buf) < self._chunk_size
         return len(b)
 


### PR DESCRIPTION
This improves exception chaining and fixes a case where we'd get a BufferError after an exception. The bad case is if you have a finally block that writes to the file after an exception, e.g. if you use a gzip file in a context manager it will write a trailer to the underlying file on close.

Here is a test (will commit once blobfile tests work again):
```
import blobfile
import contextlib
import unittest.mock

@contextlib.contextmanager
def trailer_file(fn: str):
    bf = blobfile.create_context(azure_write_chunk_size=1024)
    with bf.BlobFile(fn, "wb", streaming=True) as f:
        try:
            yield f
        finally:
            f.write(b"asdf" * 1024)

def main():
    with trailer_file("az://oaishantanu/mess/xx.tmp") as f:
        with unittest.mock.patch("blobfile._azure.execute_api_request") as mock:
            mock.side_effect = RuntimeError("asdf")
            f.write(b"asdf")
            f.write(b"asdf" * 1024 * 2)
            assert mock.call_count == 1

main()
```