### PR TITLE
Fix glob for blobs with unicode characters

### DIFF
--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -1166,7 +1166,7 @@ def _expand_implicit_dirs(root: str, it: Iterator[DirEntry]) -> Iterator[DirEntr
             cur += part
             yield entry_from_dirpath(cur)
         yield entry
-        assert entry_slash_path >= previous_path
+        # assert entry_slash_path.encode("utf_16_be") >= previous_path.encode("utf_16_be")
         previous_path = entry_slash_path
 
 


### PR DESCRIPTION
Azure promises the following:

> Blobs are listed in alphabetical order in the response body, with upper-case letters listed first.

Of course it turns out that Azure has a weird definition of alphabetical. Based on writing a blob with every Unicode character, it appears to be ordered by UTF-16-BE

I'm not sure what GCS does, so I opted to just remove the assert. In general, implicit dirs are sort of problematic and not too useful.