### PR TITLE
Add last_version_seen to get the current version of an open file

### DIFF
--- a/blobfile/__init__.py
+++ b/blobfile/__init__.py
@@ -25,6 +25,7 @@ from blobfile._ops import (
     set_mtime as set_mtime,
     configure as configure,
     BlobFile as BlobFile,
+    last_version_seen as last_version_seen,
 )
 from blobfile._context import Context as Context, create_context as create_context
 from blobfile._common import (

--- a/blobfile/_azure.py
+++ b/blobfile/_azure.py
@@ -1024,7 +1024,9 @@ def create_page_iterator(
 
 
 class StreamingReadFile(BaseStreamingReadFile):
-    def __init__(self, conf: Config, path: str, size: Optional[int], version: Optional[str]) -> None:
+    def __init__(
+        self, conf: Config, path: str, size: Optional[int], version: Optional[str]
+    ) -> None:
         self._version: Optional[str] = version
         if size is None:
             st = maybe_stat(conf, path, version=version)

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -559,6 +559,7 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
                 return resp
             else:
                 message = f"unexpected status {resp.status}"
+                error_class = RequestFailure
                 if url.startswith(GCP_BASE_URL):
                     if resp.status in (429, 503):
                         message += ": if you are writing a blob this error may be due to multiple concurrent writers - make sure you are not writing to the same blob from multiple processes simultaneously"
@@ -566,7 +567,10 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
                         message += ": no valid credentials were found, please login with 'gcloud auth application-default login' or else set the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable to the path of a JSON format service account key"
                     elif resp.status == 403:
                         message += ": credentials were found but do not grant access to this resource, please make sure the account you are using (either via 'gcloud auth application-default login' or the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable) has access"
-                err = RequestFailure.create_from_request_response(
+                elif resp.status == 412 and resp.headers["x-ms-error-code"] == "ConditionNotMet":
+                    error_class = VersionMismatch
+                    message="etag mismatch"
+                err = error_class.create_from_request_response(
                     message=message, request=req, response=resp
                 )
                 if resp.status not in req.retry_codes:

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -567,7 +567,7 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
                         message += ": no valid credentials were found, please login with 'gcloud auth application-default login' or else set the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable to the path of a JSON format service account key"
                     elif resp.status == 403:
                         message += ": credentials were found but do not grant access to this resource, please make sure the account you are using (either via 'gcloud auth application-default login' or the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable) has access"
-                elif resp.status == 412 and resp.headers["x-ms-error-code"] == "ConditionNotMet":
+                elif resp.status == 412 and resp.headers.get("x-ms-error-code") == "ConditionNotMet":
                     error_class = VersionMismatch
                     message = "etag mismatch"
                 err = error_class.create_from_request_response(

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -567,7 +567,9 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
                         message += ": no valid credentials were found, please login with 'gcloud auth application-default login' or else set the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable to the path of a JSON format service account key"
                     elif resp.status == 403:
                         message += ": credentials were found but do not grant access to this resource, please make sure the account you are using (either via 'gcloud auth application-default login' or the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable) has access"
-                elif resp.status == 412 and resp.headers.get("x-ms-error-code") == "ConditionNotMet":
+                elif (
+                    resp.status == 412 and resp.headers.get("x-ms-error-code") == "ConditionNotMet"
+                ):
                     error_class = VersionMismatch
                     message = "etag mismatch"
                 err = error_class.create_from_request_response(

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -569,7 +569,7 @@ def execute_request(conf: Config, build_req: Callable[[], Request]) -> "urllib3.
                         message += ": credentials were found but do not grant access to this resource, please make sure the account you are using (either via 'gcloud auth application-default login' or the 'GOOGLE_APPLICATION_CREDENTIALS' environment variable) has access"
                 elif resp.status == 412 and resp.headers["x-ms-error-code"] == "ConditionNotMet":
                     error_class = VersionMismatch
-                    message="etag mismatch"
+                    message = "etag mismatch"
                 err = error_class.create_from_request_response(
                     message=message, request=req, response=resp
                 )

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -856,7 +856,6 @@ class Context:
             assert mode in ("r", "rb"), "Can only specify file_size when reading"
 
         if version:
-            assert mode in ("w", "wb", "a", "ab"), "Can only specify version when writing"
             assert not _is_local_path(path), "Cannot specify version when writing to local file"
             # we check for gcp later to raise a NotImplementedError instead
 
@@ -895,7 +894,7 @@ class Context:
                 if mode in ("w", "wb"):
                     f = azure.StreamingWriteFile(self._conf, path, version)
                 elif mode in ("r", "rb"):
-                    f = azure.StreamingReadFile(self._conf, path, size=file_size)
+                    f = azure.StreamingReadFile(self._conf, path, size=file_size, version=version)
                     f = io.BufferedReader(f, buffer_size=buffer_size)
                 else:
                     raise Error(f"Unsupported mode: '{mode}'")

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -782,9 +782,9 @@ class Context:
             actual = actual.buffer
         if isinstance(actual, (io.BufferedReader, io.BufferedWriter)):
             actual = actual.raw
-        if isinstance(actual, (azure.StreamingReadFile, azure.StreamingWriteFile)):
-            return actual._version
-        return None
+        if not isinstance(actual, (azure.StreamingReadFile, azure.StreamingWriteFile)):
+            raise ValueError("File was not an Azure BlobFile opened in streaming mode")
+        return actual._version  # pyright: ignore[reportPrivateUsage]
 
     @overload
     def BlobFile(

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -776,13 +776,14 @@ class Context:
                 return common.block_md5(f).hex()
 
     def last_version_seen(self, file: TextIO | BinaryIO) -> Optional[str]:
+        actual: object
         actual = file
         if isinstance(actual, io.TextIOWrapper):
             actual = actual.buffer
         if isinstance(actual, (io.BufferedReader, io.BufferedWriter)):
             actual = actual.raw
         if isinstance(actual, (azure.StreamingReadFile, azure.StreamingWriteFile)):
-            return actual._version  # type: ignore
+            return actual._version
         return None
 
     @overload

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -36,9 +36,8 @@ from typing import (
     overload,
 )
 
-import urllib3
-
 import filelock
+import urllib3
 
 from blobfile import _azure as azure
 from blobfile import _common as common
@@ -50,10 +49,10 @@ from blobfile._common import (
     Config,
     DirEntry,
     Error,
+    RemoteOrLocalPath,
     Request,
     RestartableStreamingWriteFailure,
     Stat,
-    RemoteOrLocalPath,
     get_log_threshold_for_error,
     path_to_str,
 )
@@ -775,6 +774,16 @@ class Context:
         else:
             with self.BlobFile(path, "rb") as f:
                 return common.block_md5(f).hex()
+
+    def last_version_seen(self, file: TextIO | BinaryIO) -> Optional[str]:
+        actual = file
+        if isinstance(actual, io.TextIOWrapper):
+            actual = actual.buffer
+        if isinstance(actual, (io.BufferedReader, io.BufferedWriter)):
+            actual = actual.raw
+        if isinstance(actual, (azure.StreamingReadFile, azure.StreamingWriteFile)):
+            return actual._version  # type: ignore
+        return None
 
     @overload
     def BlobFile(

--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -16,7 +16,7 @@ from typing import (
 
 import urllib3
 
-from blobfile._common import DirEntry, Stat, RemoteOrLocalPath
+from blobfile._common import DirEntry, RemoteOrLocalPath, Stat
 from blobfile._context import (
     DEFAULT_AZURE_WRITE_CHUNK_SIZE,
     DEFAULT_BUFFER_SIZE,
@@ -297,6 +297,13 @@ def md5(path: RemoteOrLocalPath) -> str:
     For local paths, this must always calculate the MD5.
     """
     return default_context.md5(path=path)
+
+
+def last_version_seen(file: TextIO | BinaryIO) -> Optional[str]:
+    """
+    Get the last seen version of a file opened with `BlobFile`
+    """
+    return default_context.last_version_seen(file=file)
 
 
 @overload

--- a/blobfile/_ops_test.py
+++ b/blobfile/_ops_test.py
@@ -1467,6 +1467,11 @@ def test_azure_etags_last_version(ctx):
         version1 = bf.last_version_seen(f)
         version2 = bf.last_version_seen(f2)
         assert version1 != version2
+
+        with pytest.raises(bf.VersionMismatch):
+            with bf.BlobFile(path, "rb", streaming=True, version=version1) as f:
+                assert f.read() == data1
+
         with bf.BlobFile(path, "rb", streaming=True) as f:
             assert f.read() == data2
         read_version = bf.last_version_seen(f)


### PR DESCRIPTION
The intent of this function is to guarantee that the version (etag) one gets corresponds to the content one has read (or written). This can be useful, for instance, when generating an index referencing another blob.

We also add support for passing `version` when opening a file for streaming read.

Builds on https://github.com/blobfile/blobfile/pull/243 and should be merged after it.