### PR TITLE
Add option to support blind writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ There are a few bonus functions:
     * `use_azure_storage_account_key_fallback=False`: fallback to storage account keys for azure containers, having this enabled requires listing your subscriptions and may run into 429 errors if you hit the low azure quotas for subscription listing
     * `get_http_pool=None`: a function that returns a `urllib3.PoolManager` to be used for requests
     * `use_streaming_read=False`: if set to `True`, use a single read per file instead of reading a chunk at a time (not recommended for azure)
+    * `use_blind_writes=False`: if set to `True`, skip certain read checks during Azure writes. Defaults to checking if `BLOBFILE_USE_BLIND_WRITES` is set to `1`.
     * `default_buffer_size=io.DEFAULT_BUFFER_SIZE`: the default buffer size to use for reading files (and writing local files)
     * `save_access_token_to_disk=True`: if set to `True` to save access tokens to disk so that other processes can read the access tokens to avoid the small amount of time it usually takes to get a token (if the token is still valid).
     * `multiprocessing_start_method="spawn"`: the start method to use when creating processes for parallel work

--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -326,6 +326,7 @@ class Config:
         use_azure_storage_account_key_fallback: bool,
         get_http_pool: Optional[Callable[[], urllib3.PoolManager]],
         use_streaming_read: bool,
+        use_blind_writes: bool,
         default_buffer_size: int,
         get_deadline: Optional[Callable[[], Optional[float]]],
         save_access_token_to_disk: bool,
@@ -344,6 +345,7 @@ class Config:
         self.output_az_paths = output_az_paths
         self.use_azure_storage_account_key_fallback = use_azure_storage_account_key_fallback
         self.use_streaming_read = use_streaming_read
+        self.use_blind_writes = use_blind_writes
         self.default_buffer_size = default_buffer_size
         self.get_deadline = get_deadline
         self.save_access_token_to_disk = save_access_token_to_disk

--- a/blobfile/_context.py
+++ b/blobfile/_context.py
@@ -68,6 +68,7 @@ DEFAULT_RETRY_COMMON_LOG_THRESHOLD = 2
 DEFAULT_CONNECT_TIMEOUT = 10
 DEFAULT_READ_TIMEOUT = 30
 DEFAULT_BUFFER_SIZE = 8 * 2**20
+DEFAULT_USE_BLIND_WRITES = os.getenv("BLOBFILE_USE_BLIND_WRITES", "0") == "1"
 
 
 def _execute_fn_and_ignore_result(fn: Callable[..., object], *args: Any):
@@ -1487,6 +1488,7 @@ def create_context(
     use_azure_storage_account_key_fallback: bool = False,
     get_http_pool: Optional[Callable[[], urllib3.PoolManager]] = None,
     use_streaming_read: bool = False,
+    use_blind_writes: bool = DEFAULT_USE_BLIND_WRITES,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,
     get_deadline: Optional[Callable[[], float]] = None,
     save_access_token_to_disk: bool = True,
@@ -1511,6 +1513,7 @@ def create_context(
         get_http_pool=get_http_pool,
         use_streaming_read=use_streaming_read,
         default_buffer_size=default_buffer_size,
+        use_blind_writes=use_blind_writes,
         get_deadline=get_deadline,
         save_access_token_to_disk=save_access_token_to_disk,
         multiprocessing_start_method=multiprocessing_start_method,

--- a/blobfile/_ops.py
+++ b/blobfile/_ops.py
@@ -27,6 +27,7 @@ from blobfile._context import (
     DEFAULT_READ_TIMEOUT,
     DEFAULT_RETRY_COMMON_LOG_THRESHOLD,
     DEFAULT_RETRY_LOG_THRESHOLD,
+    DEFAULT_USE_BLIND_WRITES,
     create_context,
     default_log_fn,
 )
@@ -52,6 +53,7 @@ def configure(
     use_azure_storage_account_key_fallback: bool = False,
     get_http_pool: Optional[Callable[[], urllib3.PoolManager]] = None,
     use_streaming_read: bool = False,
+    use_blind_writes: bool = DEFAULT_USE_BLIND_WRITES,
     default_buffer_size: int = DEFAULT_BUFFER_SIZE,
     save_access_token_to_disk: bool = True,
     multiprocessing_start_method: str = "spawn",
@@ -69,6 +71,7 @@ def configure(
     use_azure_storage_account_key_fallback: fallback to storage account keys for azure containers, having this enabled requires listing your subscriptions and may run into 429 errors if you hit the low azure quotas for subscription listing
     get_http_pool: a function that returns a `urllib3.PoolManager` to be used for requests
     use_streaming_read: if set to `True`, use a single read per file instead of reading a chunk at a time (not recommended for azure)
+    use_blind_writes: if set to `True`, skip certain read checks during Azure writes
     default_buffer_size: the default buffer size to use for reading files (and writing local files)
     save_access_token_to_disk: set to `True` to save access tokens to disk so that other processes can read the access tokens to avoid the small amount of time it usually takes to get a token (if the token is still valid).
     multiprocessing_start_method: the start method to use when creating processes for parallel work
@@ -89,6 +92,7 @@ def configure(
         use_azure_storage_account_key_fallback=use_azure_storage_account_key_fallback,
         get_http_pool=get_http_pool,
         use_streaming_read=use_streaming_read,
+        use_blind_writes=use_blind_writes,
         default_buffer_size=default_buffer_size,
         save_access_token_to_disk=save_access_token_to_disk,
         multiprocessing_start_method=multiprocessing_start_method,

--- a/blobfile/_ops_test.py
+++ b/blobfile/_ops_test.py
@@ -1684,7 +1684,5 @@ def test_use_blind_writes_skips_uncommited_blocks_check():
 def test_use_blind_writes_skips_can_access_container():
     ctx = bf.create_context(use_blind_writes=True)
     with unittest.mock.patch("blobfile._azure.common.execute_request") as mock_exec:
-        assert azure._can_access_container(
-            ctx._conf, "acc", "container", (azure.ANONYMOUS, ""), []
-        )
+        assert azure._can_access_container(ctx._conf, "acc", "container", (azure.ANONYMOUS, ""), [])
         mock_exec.assert_not_called()


### PR DESCRIPTION
Adds `use_blind_writes` and the corresponding env var `BLOBFILE_USE_BLIND_WRITES`. If the env var is set (and not overridden by the config) or if the config value is set to True, this causes blobfile to skip logic in the write path for Azure blobs that would require read permissions:

- skips the check that the discovered credentials actually grant read access to the container
- skips the check for too many uncommitted blocks / existing blob of wrong type

Tested locally against an Azure container to confirm that with this set you can write blobs without read perms.