### PR TITLE
Handle EAI_NODATA in _bad_hostname_check

### DIFF
--- a/blobfile/_common.py
+++ b/blobfile/_common.py
@@ -410,7 +410,7 @@ def _check_hostname(hostname: str) -> int:
         try:
             socket.getaddrinfo(hostname, None, family=socket.AF_INET)
         except socket.gaierror as e:
-            if e.errno != socket.EAI_NONAME:
+            if e.errno != socket.EAI_NONAME and e.errno != socket.EAI_NODATA:
                 # we got some sort of other socket error, so it's unclear if the host exists or not
                 return HOSTNAME_STATUS_UNKNOWN
 


### PR DESCRIPTION
On Ubuntu 24.04, looking up an unresolveable
`<something>.blob.core.windows.net` returns `EAI_NODATA`, not `EAI_NONAME`. The result is that `bbb ls az://<something>` gets stuck in a backoff loop instead of returning a `FileNotFoundError`.

Based off Eben's original changes in [boostedblob](https://github.com/hauntsaninja/boostedblob/commit/5b2339915588abb58c4685eddb3fca6ec7c7b855) 